### PR TITLE
Create skeleton Next.js app from PRD

### DIFF
--- a/app/admin/marketplace/page.tsx
+++ b/app/admin/marketplace/page.tsx
@@ -1,0 +1,14 @@
+'use client'
+import Nav from '@/components/Nav'
+
+export default function Marketplace() {
+  return (
+    <div>
+      <Nav />
+      <div className="p-4">
+        <h1 className="text-xl mb-2">Marketplace</h1>
+        <p>Install and manage agents here.</p>
+      </div>
+    </div>
+  )
+}

--- a/app/api/agent/[agentId]/webhook/route.ts
+++ b/app/api/agent/[agentId]/webhook/route.ts
@@ -1,0 +1,13 @@
+import { tasks } from '@/lib/data'
+
+export async function POST(req: Request, context: any) {
+  const body = await req.json()
+  if (body.action === 'completeTask') {
+    const task = tasks.find(t => t.id === body.taskId)
+    if (task) {
+      task.status = 'done'
+      return Response.json({ ok: true })
+    }
+  }
+  return new Response('Bad request', { status: 400 })
+}

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest } from 'next/server'
+import { messages, Message } from '@/lib/data'
+
+export async function POST(req: NextRequest) {
+  const body = await req.json()
+  const userMsg: Message = { role: 'user', content: body.content || '' }
+  messages.push(userMsg)
+  const assistantReply: Message = {
+    role: 'assistant',
+    content: `Echo: ${userMsg.content}`,
+  }
+  messages.push(assistantReply)
+  return Response.json({ message: assistantReply })
+}

--- a/app/api/memory/search/route.ts
+++ b/app/api/memory/search/route.ts
@@ -1,0 +1,8 @@
+import { memory } from '@/lib/data'
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url)
+  const q = searchParams.get('q')?.toLowerCase() || ''
+  const results = memory.filter(m => m.text.toLowerCase().includes(q))
+  return Response.json({ results })
+}

--- a/app/api/stream/route.ts
+++ b/app/api/stream/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest } from 'next/server'
+import { tasks } from '@/lib/data'
+
+export const runtime = 'edge'
+
+export async function GET(req: NextRequest) {
+  const { readable, writable } = new TransformStream()
+  const encoder = new TextEncoder()
+  const writer = writable.getWriter()
+
+  const send = () => {
+    const data = JSON.stringify({ tasks })
+    writer.write(encoder.encode(`event: task_update\ndata: ${data}\n\n`))
+  }
+
+  const interval = setInterval(send, 3000)
+  send()
+
+  req.signal.addEventListener('abort', () => {
+    clearInterval(interval)
+    writer.close()
+  })
+
+  return new Response(readable, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    },
+  })
+}

--- a/app/api/tasks/[id]/route.ts
+++ b/app/api/tasks/[id]/route.ts
@@ -1,0 +1,12 @@
+import { tasks } from '@/lib/data'
+
+export async function POST(req: Request, context: any) {
+  const { params } = context
+  const body = await req.json()
+  const task = tasks.find(t => t.id === params.id)
+  if (task) {
+    task.status = body.status || task.status
+    return Response.json({ ok: true, task })
+  }
+  return new Response('Not found', { status: 404 })
+}

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -1,0 +1,14 @@
+'use client'
+import Nav from '@/components/Nav'
+
+export default function Calendar() {
+  return (
+    <div>
+      <Nav />
+      <div className="p-4">
+        <h1 className="text-xl mb-2">Calendar</h1>
+        <p>Calendar integration coming soon.</p>
+      </div>
+    </div>
+  )
+}

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -1,0 +1,47 @@
+'use client'
+import { useState, useEffect } from 'react'
+import Nav from '@/components/Nav'
+
+interface Msg {
+  role: 'user' | 'assistant'
+  content: string
+}
+
+export default function ChatPage() {
+  const [messages, setMessages] = useState<Msg[]>([])
+  const [input, setInput] = useState('')
+
+  const send = async () => {
+    const res = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: input }),
+    })
+    const data = await res.json()
+    setMessages(prev => [...prev, { role: 'user', content: input }, data.message])
+    setInput('')
+  }
+
+  return (
+    <div>
+      <Nav />
+      <div className="p-4 flex flex-col gap-2">
+        {messages.map((m, i) => (
+          <div key={i} className="p-2 border rounded">
+            <b>{m.role}:</b> {m.content}
+          </div>
+        ))}
+        <div className="flex gap-2 mt-2">
+          <input
+            className="border flex-1 p-2"
+            value={input}
+            onChange={e => setInput(e.target.value)}
+          />
+          <button onClick={send} className="px-4 py-2 bg-blue-500 text-white rounded">
+            Send
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/inbox/page.tsx
+++ b/app/inbox/page.tsx
@@ -1,0 +1,33 @@
+'use client'
+import { useEffect, useState } from 'react'
+import Nav from '@/components/Nav'
+import { Task } from '@/lib/data'
+
+export default function Inbox() {
+  const [tasks, setTasks] = useState<Task[]>([])
+
+  useEffect(() => {
+    const es = new EventSource('/api/stream')
+    es.onmessage = e => {
+      const parsed = JSON.parse(e.data)
+      setTasks(parsed.tasks)
+    }
+    return () => es.close()
+  }, [])
+
+  return (
+    <div>
+      <Nav />
+      <div className="p-4">
+        <h1 className="text-xl mb-2">Inbox</h1>
+        <ul className="flex flex-col gap-2">
+          {tasks.map(t => (
+            <li key={t.id} className="border p-2 rounded">
+              <b>{t.content}</b> - {t.status}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,103 +1,13 @@
-import Image from "next/image";
+import Nav from '@/components/Nav'
 
 export default function Home() {
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="list-inside list-decimal text-sm/6 text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-[family-name:var(--font-geist-mono)] font-semibold">
-              app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
+    <div>
+      <Nav />
+      <main className="p-4">
+        <h1 className="text-xl mb-4">Samantha Platform</h1>
+        <p>Welcome. Use the navigation to access Chat, Inbox, Calendar and more.</p>
       </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
     </div>
-  );
+  )
 }

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,14 @@
+'use client'
+import Nav from '@/components/Nav'
+
+export default function Settings() {
+  return (
+    <div>
+      <Nav />
+      <div className="p-4">
+        <h1 className="text-xl mb-2">Settings</h1>
+        <p>Manage your profile and API keys.</p>
+      </div>
+    </div>
+  )
+}

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link'
+
+export default function Nav() {
+  return (
+    <nav className="flex gap-4 p-4 border-b border-gray-300 text-sm">
+      <Link href="/chat">Chat</Link>
+      <Link href="/inbox">Inbox</Link>
+      <Link href="/calendar">Calendar</Link>
+      <Link href="/admin/marketplace">Marketplace</Link>
+      <Link href="/settings">Settings</Link>
+    </nav>
+  )
+}

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,0 +1,20 @@
+export interface Message {
+  role: 'user' | 'assistant'
+  content: string
+}
+
+export interface Task {
+  id: string
+  content: string
+  status: 'pending' | 'in-progress' | 'done'
+}
+
+export interface MemoryItem {
+  id: string
+  text: string
+  visibility: 'private' | 'team' | 'public'
+}
+
+export const messages: Message[] = []
+export const tasks: Task[] = []
+export const memory: MemoryItem[] = []

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from 'tailwindcss'
+
+const config: Config = {
+  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}
+
+export default config


### PR DESCRIPTION
## Summary
- add navigation bar
- build Chat, Inbox, Calendar, Marketplace and Settings pages
- scaffold API routes for chat, stream, tasks, memory and agent webhooks
- provide simple in-memory data store
- configure Tailwind

## Testing
- `npx tsc --noEmit`
- `npm run build`
- `npm test` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_68621c44e9e883239f76742e9de028f5