### PR TITLE
Add sample Next.js pages and APIs

### DIFF
--- a/app/admin/marketplace/page.tsx
+++ b/app/admin/marketplace/page.tsx
@@ -1,0 +1,41 @@
+'use client';
+import { useState } from 'react';
+
+export default function MarketplacePage() {
+  const [installed, setInstalled] = useState<string[]>(['MarketResearch']);
+  const [newAgent, setNewAgent] = useState('');
+
+  const addAgent = () => {
+    if (newAgent) {
+      setInstalled((a) => [...a, newAgent]);
+      setNewAgent('');
+    }
+  };
+
+  return (
+    <div className="p-4 max-w-xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Marketplace</h1>
+      <ul className="mb-4 space-y-2">
+        {installed.map((a) => (
+          <li key={a} className="p-2 border rounded">
+            {a}
+          </li>
+        ))}
+      </ul>
+      <div className="flex gap-2">
+        <input
+          value={newAgent}
+          onChange={(e) => setNewAgent(e.target.value)}
+          className="border rounded flex-1 p-2"
+          placeholder="New agent name"
+        />
+        <button
+          onClick={addAgent}
+          className="bg-blue-500 text-white px-4 py-2 rounded"
+        >
+          Add
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { messages, Message } from '@/lib/data';
+import { v4 as uuidv4 } from 'uuid';
+
+export async function POST(req: Request) {
+  const { role, content } = await req.json();
+  const reply: Message = {
+    id: uuidv4(),
+    role: 'assistant',
+    content: `Echo: ${content}`,
+    createdAt: Date.now(),
+  };
+  messages.push({ id: uuidv4(), role, content, createdAt: Date.now() });
+  messages.push(reply);
+  return NextResponse.json(reply);
+}

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server';
+import { events } from '@/lib/data';
+
+export async function GET() {
+  return NextResponse.json(events);
+}

--- a/app/api/memory/route.ts
+++ b/app/api/memory/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+import { messages } from '@/lib/data';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const q = (searchParams.get('q') || '').toLowerCase();
+  const results = messages.filter((m) => m.content.toLowerCase().includes(q));
+  return NextResponse.json(results);
+}

--- a/app/api/tasks/[id]/route.js
+++ b/app/api/tasks/[id]/route.js
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+import { tasks } from '@/lib/data';
+
+export async function POST(req, context) {
+  const { status } = await req.json();
+  const task = tasks.find((t) => t.id === context.params.id);
+  if (task) {
+    task.status = status;
+  }
+  return NextResponse.json(task || {});
+}

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server';
+import { tasks } from '@/lib/data';
+
+export async function GET() {
+  return NextResponse.json(tasks);
+}

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -1,0 +1,33 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+interface Event {
+  id: string;
+  title: string;
+  start: string;
+  end: string;
+}
+
+export default function CalendarPage() {
+  const [events, setEvents] = useState<Event[]>([]);
+
+  useEffect(() => {
+    fetch('/api/events')
+      .then((r) => r.json())
+      .then(setEvents);
+  }, []);
+
+  return (
+    <div className="p-4 max-w-xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Calendar</h1>
+      <ul className="space-y-2">
+        {events.map((ev) => (
+          <li key={ev.id} className="p-2 border rounded">
+            {ev.title}: {new Date(ev.start).toLocaleString()} -
+            {new Date(ev.end).toLocaleString()}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -1,0 +1,53 @@
+'use client';
+import { useEffect, useState, FormEvent } from 'react';
+
+interface Message {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export default function ChatPage() {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
+
+  const sendMessage = async (e: FormEvent) => {
+    e.preventDefault();
+    const res = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ role: 'user', content: input }),
+    });
+    const data = await res.json();
+    setMessages((prev) => [
+      ...prev,
+      { id: crypto.randomUUID(), role: 'user', content: input },
+      data,
+    ]);
+    setInput('');
+  };
+
+  return (
+    <div className="p-4 max-w-xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Chat with Samantha</h1>
+      <div className="space-y-2 mb-4">
+        {messages.map((m) => (
+          <div key={m.id} className="p-2 border rounded">
+            <strong>{m.role}: </strong>
+            {m.content}
+          </div>
+        ))}
+      </div>
+      <form onSubmit={sendMessage} className="flex gap-2">
+        <input
+          className="border rounded flex-1 p-2"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+        />
+        <button className="bg-blue-500 text-white px-4 py-2 rounded" type="submit">
+          Send
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/app/inbox/page.tsx
+++ b/app/inbox/page.tsx
@@ -1,0 +1,50 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+interface Task {
+  id: string;
+  title: string;
+  status: 'pending' | 'in-progress' | 'done';
+}
+
+export default function InboxPage() {
+  const [tasks, setTasks] = useState<Task[]>([]);
+
+  useEffect(() => {
+    fetch('/api/tasks')
+      .then((r) => r.json())
+      .then(setTasks);
+  }, []);
+
+  const markDone = async (id: string) => {
+    await fetch(`/api/tasks/${id}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'done' }),
+    });
+    setTasks((t) => t.map((x) => (x.id === id ? { ...x, status: 'done' } : x)));
+  };
+
+  return (
+    <div className="p-4 max-w-xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Inbox</h1>
+      <ul className="space-y-2">
+        {tasks.map((task) => (
+          <li key={task.id} className="p-2 border rounded flex justify-between">
+            <span>
+              {task.title} ({task.status})
+            </span>
+            {task.status !== 'done' && (
+              <button
+                onClick={() => markDone(task.id)}
+                className="bg-green-500 text-white px-2 py-1 rounded"
+              >
+                Complete
+              </button>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,103 +1,26 @@
-import Image from "next/image";
+import Link from 'next/link';
 
 export default function Home() {
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="list-inside list-decimal text-sm/6 text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-[family-name:var(--font-geist-mono)] font-semibold">
-              app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
+    <div className="p-4 max-w-xl mx-auto space-y-4">
+      <h1 className="text-2xl font-bold">Agentic Workflow Platform</h1>
+      <p>Select a page to explore:</p>
+      <ul className="space-y-2 list-disc list-inside">
+        <li>
+          <Link href="/chat" className="text-blue-600 underline">Chat</Link>
+        </li>
+        <li>
+          <Link href="/inbox" className="text-blue-600 underline">Inbox</Link>
+        </li>
+        <li>
+          <Link href="/calendar" className="text-blue-600 underline">Calendar</Link>
+        </li>
+        <li>
+          <Link href="/admin/marketplace" className="text-blue-600 underline">
+            Marketplace
+          </Link>
+        </li>
+      </ul>
     </div>
   );
 }

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,0 +1,34 @@
+export interface Message {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  createdAt: number;
+}
+
+export interface Task {
+  id: string;
+  title: string;
+  status: 'pending' | 'in-progress' | 'done';
+}
+
+export interface CalendarEvent {
+  id: string;
+  title: string;
+  start: string; // ISO date string
+  end: string;
+}
+
+export const messages: Message[] = [];
+export const tasks: Task[] = [
+  { id: '1', title: 'Review draft', status: 'pending' },
+  { id: '2', title: 'Schedule meeting', status: 'in-progress' },
+];
+
+export const events: CalendarEvent[] = [
+  {
+    id: '1',
+    title: 'Kickoff',
+    start: new Date().toISOString(),
+    end: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+  },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,15 @@
       "dependencies": {
         "next": "15.3.4",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/uuid": "^10.0.0",
         "tailwindcss": "^4",
         "typescript": "^5"
       }
@@ -975,6 +977,13 @@
         "@types/react": "^19.0.0"
       }
     },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -1738,6 +1747,19 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/yallist": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -9,16 +9,18 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "next": "15.3.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "next": "15.3.4"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4"
+    "@types/uuid": "^10.0.0",
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }


### PR DESCRIPTION
## Summary
- create in-memory data store for messages, tasks, events
- add simple chat, inbox, calendar and marketplace pages
- implement stub API routes for chat, tasks, events and memory search
- update home page with links to new screens
- add uuid package for id generation

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68621c44e9e883239f76742e9de028f5